### PR TITLE
Corrects typos and extra spaces.

### DIFF
--- a/tex/1q-1h-hartree-fock.tex
+++ b/tex/1q-1h-hartree-fock.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT
@@ -411,7 +411,7 @@ This implies that the solution to the Hartree-Fock optimization problem is not u
 In this section we show how to use this freedom to our advantage, by choosing orbitals which diagonalize the Lagrange multiplier matrix, partially decoupling \cref{eq:hartree-fock-noncanonical-stationarity-condition}.
 These orbitals are known as \textit{canonical Hartree-Fock orbitals}.
 
-In matrix notation, the Hatree-Fock equations can be written as follows.
+In matrix notation, the Hartree-Fock equations can be written as follows.
 \begin{align}\label{eq:hartree-fock-noncanonical-stationarity-condition-matrix-form}
   \op{f}\bm\y
 \overset{!}=
@@ -472,7 +472,7 @@ Substituting the new orbitals into \cref{eq:hartree-fock-noncanonical-stationari
 \end{align*}
 Since $\bm{\ev}$ is Hermitian, the Lagrangian eigenvalues are real.
 Note that these equations are not fully decoupled, since $\op{f}$ still depends on the full orbital set $\{\y_i\}$.
-Solving them amounts to solving for the {\it self-consistent field} 
+Solving them amounts to solving for the {\it self-consistent field}
 \begin{align}
   \op{v}(1)
 \equiv
@@ -499,7 +499,7 @@ In this approach, we define the ``Lagrangian function'' $\mc{L}$ as
   \la(g(x,y)-c)
 \end{align}
 where the parameter $\la$ is called the Lagrange multiplier.
-The contrained optimization problem can be solved solved by optimizing $\mc{L}$ with respect to $x$, $y$, and $\la$.
+The constrained optimization problem can be solved solved by optimizing $\mc{L}$ with respect to $x$, $y$, and $\la$.
 To see why, consider the stationarity conditions for $\mc{L}$.
 \begin{align}
   \pd{\mc{L}}{x}

--- a/tex/1q-1p-hartree-fock.tex
+++ b/tex/1q-1p-hartree-fock.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT

--- a/tex/1q-2h-second-quantization.tex
+++ b/tex/1q-2h-second-quantization.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT
@@ -105,7 +105,7 @@ Therefore, matrix elements of the electronic Hamiltonian with respect to $\Y,\Y'
   \ip{pq|rs}\ip{\op{a}_q\op{a}_p\Y|\op{a}_s\op{a}_r\Y'}
 \end{align*}
 in terms of the usual one- and two-electron integrals.
-Since $\Y$ and $\Y'$ are arbitary elements of $\mc{F}_n$, this implies
+Since $\Y$ and $\Y'$ are arbitrary elements of $\mc{F}_n$, this implies
 \begin{align}\label{eq:second-quantized-hamiltonian}
   \left.
   \op{H}_e
@@ -133,7 +133,7 @@ A defining feature of the second quantization formalism is that $\op{H}_e$ is in
 The \textit{direct sum}, $\oplus$, and \textit{direct product}\footnote{Also known as a \textit{tensor product}}, $\otimes$, are operations defining two different ways of combining vector spaces.
 Each operation takes a vector from one space and a vector the other to form an ordered pair, but they behave differently under vector addition and scalar multiplication.
 In a direct sum space $V\oplus V'\equiv\{v\oplus v'\,|\,v\in V,\,v'\in V'\}$,
-vector addition and scalar multilication are defined by
+vector addition and scalar multiplication are defined by
 \begin{align}
   v_1\oplus v_1'
 +
@@ -274,7 +274,7 @@ and the \textit{creation operator} of $\y_p$ is a linear mapping $c_p:\mc{F}_n(\
 
 \begin{prop}\label{prop:particle-hole-operator-anticommutator}
 \thmtitle{$[q,q']_+=\d_{q'q\dg}$}
-\thmstatement{Particle-hole operators $q$ and $q'$ anticommute unless $q'=q\dg$, for which $[q,q\dg]_+=1$.}~\footnote{These are anticommuator brackets, $[q, q']_+ \equiv qq' + q'q$.}
+\thmstatement{Particle-hole operators $q$ and $q'$ anticommute unless $q'=q\dg$, for which $[q,q\dg]_+=1$.}~\footnote{These are anticommutator brackets, $[q, q']_+ \equiv qq' + q'q$.}
 \thmproof{
   Let $q$ and $q'$ be arbitrary particle-hole operators acting on $\y_p$ and $\y_{p'}$, respectively.
   First, suppose $p\neq p'$. Then

--- a/tex/1q-2p-second-quantization.tex
+++ b/tex/1q-2p-second-quantization.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT

--- a/tex/1q-quiz-answers.tex
+++ b/tex/1q-quiz-answers.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT

--- a/tex/1q-quiz.tex
+++ b/tex/1q-quiz.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT

--- a/tex/2q-1h-pople-nesbet.tex
+++ b/tex/2q-1h-pople-nesbet.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT
@@ -69,7 +69,7 @@ A complete set of one-electron functions (spin-orbitals) comes in $\a,\b$-pairs.
 =
   \f_{p_\b}(\bo{r})\b(s)
 \end{align}
-The spatial components of these functions can be expanded in terms of a set of AO basis functions $\{\x_\nu\}$ as 
+The spatial components of these functions can be expanded in terms of a set of AO basis functions $\{\x_\nu\}$ as
 \begin{align}\label{eq:space-orb}
   \f_{p_\a}
 =
@@ -323,7 +323,7 @@ After diagonalizing the transformed Fock matrix, $\tl{\bo{F}}$, the MO coefficie
 
 \begin{samepage}
 Equation \ref{orthogonalized-roothaan-hall} is still not exactly an ordinary eigenvalue problem because $\bo{F}$ depends on the MOs via the density matrix $\bo{D}$.
-The standard procedure for solving the Roothan-Hall equations repeatedly diagonalizes $\tl{\bo{F}}$ and feeds in the new density until the equation becomes self-consistent.
+The standard procedure for solving the Roothaan-Hall equations repeatedly diagonalizes $\tl{\bo{F}}$ and feeds in the new density until the equation becomes self-consistent.
 The algorithm looks as follows.
 \begin{enumerate}
   \item Get integrals $\ip{\x_\mu|\x_\nu}, \ip{\x_\mu|\op{h}|\x_\nu}, \ip{\x_\mu\x_\nu|\x_\rho\x_\si}$ and form orthogonalizer $\bo{S}^{-\frac{1}{2}}$

--- a/tex/2q-1p-pople-nesbet.tex
+++ b/tex/2q-1p-pople-nesbet.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT
@@ -60,7 +60,7 @@
   \end{align*}
 
 \item
-  Expand the spatial orbtials in problem 1.~as
+  Expand the spatial orbitals in problem 1.~as
   $
     \f_{p_\w}
   =

--- a/tex/2q-2h-wicks-theorem.tex
+++ b/tex/2q-2h-wicks-theorem.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT
@@ -442,7 +442,7 @@ Substituting these into the electronic Hamiltonian leads to an expression for $H
   \g_{rs}
 \end{array}
 \end{align}
-Note that $E_0$ is another expression for the Hartree-Fock energy, $E_0=\ip{\F|\op{H}_e|\F}$, and $f_{pq}$ is the matrix representation of the the Fock operator in the spin-orbital basis, $\bm{f}=[f_{pq}]$ where $f_{pq}=\ip{\y_p|\op{f}\y_q}$.
+Note that $E_0$ is another expression for the Hartree-Fock energy, $E_0=\ip{\F|\op{H}_e|\F}$, and $f_{pq}$ is the matrix representation of the Fock operator in the spin-orbital basis, $\bm{f}=[f_{pq}]$ where $f_{pq}=\ip{\y_p|\op{f}\y_q}$.
 The second and third terms in this expression together make up the \textit{correlation component} of the electronic Hamiltonian, $H_\mr{c}\equiv H_e - \ip{\F|H_e|\F}$.
 \end{dfn}
 
@@ -572,7 +572,7 @@ Multiplying these by $f_{pq}$ and $\tfr{1}{4}\ip{pq||rs}$ and summing over Hamil
   For any non-commuting $x_1,\ld,x_n$, and $y$ for which addition, subtraction and multiplication are defined, $x_1\cd x_ny=\pr{\mp}^nyx_1\cd x_n+\sum_{k=1}^n\pr{\mp}^{n-k}x_1\cd[x_k,y]_{\pm}\cd x_n$, where $[x,y]_{\pm}\equiv xy\pm yx$.
 }
 \thmproof{
-  The $n=1$ case folows from the definition of the commutator brackets: $xy=\mp yx+[x,y]_{\pm}$.
+  The $n=1$ case follows from the definition of the commutator brackets: $xy=\mp yx+[x,y]_{\pm}$.
   Now, assume it holds for $n$ and consider the $n+1$ case.
   Since $x_1\cd x_{n+1}y=x_1\cd x_n(\mp yx_{n+1}+[x_{n+1},y]_{\pm})$, we find
   \begin{align*}

--- a/tex/2q-2p-wicks-theorem.tex
+++ b/tex/2q-2p-wicks-theorem.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT

--- a/tex/2q-quiz-answers.tex
+++ b/tex/2q-quiz-answers.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT
@@ -93,7 +93,7 @@
   \end{align*}
   Since there are different numbers of occupied $\a$ and $\b$ orbitals, the $\a$ and $\b$ density matrices will differ even for matching MO coefficients.
   This results in different exchange fields for $\op{f}_\a$ and $\op{f}_\b$, breaking the orbital degeneracy.
-  
+
 
 \newpage
 \item

--- a/tex/2q-quiz.tex
+++ b/tex/2q-quiz.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT
@@ -59,8 +59,8 @@
     \ev_p\d_{pq}
   \end{align*}
   \textbf{For extra credit}, you may also briefly answer the following question in words: For an open-shell system, why do we end up with different spatial orbitals for different spins, even though the initial core-guess orbitals are the same for each spin?
-  
-  
+
+
 
 \newpage
 \item

--- a/tex/3q-1h-kutzelnigg-mukherjee.tex
+++ b/tex/3q-1h-kutzelnigg-mukherjee.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT

--- a/tex/3q-1p-kutzelnigg-mukherjee.tex
+++ b/tex/3q-1p-kutzelnigg-mukherjee.tex
@@ -4,7 +4,7 @@
 \usepackage{avcgreek}
 \usepackage{avcfonts}
 \usepackage{avcmath}
-\usepackage[numberby=section]{avcthm} % 
+\usepackage[numberby=section]{avcthm}
 \usepackage{qcmacros}
 \usepackage{goldstone}
 %%MACROS FOR THIS DOCUMENT


### PR DESCRIPTION
Uses spellcheck to catch typing errors and deletes extra trailing spaces. I can't compile to make sure I didn't break anything, as I don't have your sty files.

Handy command for deleting extra spaces in Vim, just hit <F5>
```vim
" Remove trailing whitespace
nnoremap <F5> :let _s=@/<Bar>:%s/\s\+$//e<Bar>:let @/=_s<Bar><CR>
```